### PR TITLE
Bump ngrok@0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ngrok"
   ],
   "dependencies": {
-    "ngrok": "0.1.98",
+    "ngrok": "0.2.1",
     "extend": "2.0.0"
   },
   "author": "Tony Kovanen <tonykovanen@hotmail.com>",


### PR DESCRIPTION
`ngrok@0.1.98` install fails, also does `0.1.99`
- Fix rase-/zuul-ngrok/issues/5
- Close rase-/zuul-ngrok/issues/4
